### PR TITLE
fix: adapt to rosbag2 foxy changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(rcpputils REQUIRED)
 find_package(rmw_fastrtps_cpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
-find_package(rosbag2 REQUIRED)
+find_package(rosbag2_cpp REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(Boost REQUIRED COMPONENTS container)
 
@@ -39,7 +39,7 @@ ament_target_dependencies(${PROJECT_NAME}
   sensor_msgs
   geometry_msgs
   rmw_fastrtps_cpp
-  rosbag2
+  rosbag2_cpp
 )
 
 #------------------

--- a/include/ros2_introspection/ros2_introspection.hpp
+++ b/include/ros2_introspection/ros2_introspection.hpp
@@ -35,8 +35,8 @@
 
 #include <unordered_map>
 #include <ros2_introspection/stringtree.hpp>
-#include <rosbag2/typesupport_helpers.hpp>
-#include <rosbag2/types/introspection_message.hpp>
+#include <rosbag2_cpp/typesupport_helpers.hpp>
+#include <rosbag2_cpp/types/introspection_message.hpp>
 #include <rosidl_typesupport_cpp/identifier.hpp>
 #include <rosidl_typesupport_introspection_cpp/identifier.hpp>
 
@@ -64,6 +64,7 @@ struct FlatMessage {
 typedef std::vector< std::pair<std::string, double> > RenamedValues;
 
 struct Ros2MessageInfo{
+  std::shared_ptr<rcpputils::SharedLibrary> type_support_library;
   const rosidl_message_type_support_t* type_support;
   StringTree field_tree;
 };

--- a/src/ros2_introspection.cpp
+++ b/src/ros2_introspection.cpp
@@ -2,8 +2,8 @@
 
 #include <rosidl_typesupport_introspection_cpp/message_introspection.hpp>
 #include <rosidl_typesupport_introspection_cpp/field_types.hpp>
-#include <rosbag2/typesupport_helpers.hpp>
-#include <rosbag2/types/introspection_message.hpp>
+#include <rosbag2_cpp/typesupport_helpers.hpp>
+#include <rosbag2_cpp/types/introspection_message.hpp>
 #include <rcutils/time.h>
 #include <functional>
 #include <cmath>
@@ -25,8 +25,9 @@ void Parser::registerMessageType(
 
   using TypeSupport = rosidl_message_type_support_t;
 
+  info.type_support_library = rosbag2_cpp::get_typesupport_library(type_name, rosidl_typesupport_introspection_cpp::typesupport_identifier);
   info.type_support =
-    rosbag2::get_typesupport(type_name, rosidl_typesupport_introspection_cpp::typesupport_identifier);
+    rosbag2_cpp::get_typesupport_handle(type_name, rosidl_typesupport_introspection_cpp::typesupport_identifier, info.type_support_library);
 
   //------- create StringTree --------
   using rosidl_typesupport_introspection_cpp::MessageMember;

--- a/test/ros2_introspection_test.cpp
+++ b/test/ros2_introspection_test.cpp
@@ -1,6 +1,7 @@
 #include <cstdio>
 #include <iostream>
 #include <ros2_introspection/ros2_introspection.hpp>
+#include <rosbag2_cpp/typesupport_helpers.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <geometry_msgs/msg/polygon.hpp>
 #include <sensor_msgs/msg/battery_state.hpp>
@@ -43,8 +44,9 @@ TEST(Ros2Introspection, Imu) {
     imu_msg.linear_acceleration_covariance[i] = 20+i;
   }
 
+  auto library = rosbag2_cpp::get_typesupport_library(topic_type, rosidl_typesupport_introspection_cpp::typesupport_identifier);
   const auto* typesupport =
-    rosbag2::get_typesupport(topic_type, rosidl_typesupport_cpp::typesupport_identifier);
+    rosbag2_cpp::get_typesupport_handle(topic_type, rosidl_typesupport_introspection_cpp::typesupport_identifier, library);
   auto serialized_msg =  RmwInterface().serialize_message(imu_msg, typesupport);
 
   Parser parser;
@@ -149,8 +151,9 @@ TEST(Ros2Introspection, Polygon) {
     polygon.points.push_back(point);
   }
 
+  auto library = rosbag2_cpp::get_typesupport_library(topic_type, rosidl_typesupport_introspection_cpp::typesupport_identifier);
   const auto* typesupport =
-    rosbag2::get_typesupport(topic_type, rosidl_typesupport_cpp::typesupport_identifier);
+    rosbag2_cpp::get_typesupport_handle(topic_type, rosidl_typesupport_introspection_cpp::typesupport_identifier, library);
   auto serialized_msg =  RmwInterface().serialize_message(polygon, typesupport);
 
   //-------------------------
@@ -242,8 +245,9 @@ TEST(Ros2Introspection, Battery) {
   battery.location = "noth_pole";
   battery.serial_number = "666";
 
+  auto library = rosbag2_cpp::get_typesupport_library(topic_type, rosidl_typesupport_introspection_cpp::typesupport_identifier);
   const auto* typesupport =
-    rosbag2::get_typesupport(topic_type, rosidl_typesupport_cpp::typesupport_identifier);
+    rosbag2_cpp::get_typesupport_handle(topic_type, rosidl_typesupport_introspection_cpp::typesupport_identifier, library);
   auto serialized_msg =  RmwInterface().serialize_message(battery, typesupport);
 
   //-------------------------
@@ -343,8 +347,9 @@ TEST(Ros2Introspection, Image) {
   image.data.front() = 111;
   image.data.back()  = 222;
 
+  auto library = rosbag2_cpp::get_typesupport_library(topic_type, rosidl_typesupport_introspection_cpp::typesupport_identifier);
   const auto* typesupport =
-    rosbag2::get_typesupport(topic_type, rosidl_typesupport_cpp::typesupport_identifier);
+    rosbag2_cpp::get_typesupport_handle(topic_type, rosidl_typesupport_introspection_cpp::typesupport_identifier, library);
   auto serialized_msg =  RmwInterface().serialize_message(image, typesupport);
 
   //-------------------------


### PR DESCRIPTION
Thanks for making this repository available! Had to make some minor tweaks to get it building with foxy.

Namely:

- Required  `rosbag` package is now `rosbag2_cpp`
- `get_typesupport` has been split into `get_typesupport_library` and `get_typesupport_handle`

Something that tripped me up - the client library needs to persist a shared pointer to the library for the lifetime of any typesupport handles.